### PR TITLE
Make sure postcss default plugins are run last

### DIFF
--- a/lib/config/buildPlugins.js
+++ b/lib/config/buildPlugins.js
@@ -155,6 +155,26 @@ function loadPluginsForType(type, options, version, compress) {
   // Start with default if available
   let plugins = type in allPlugins && allPlugins[type].default ? allPlugins[type].default.slice() : [];
 
+  // Add plugins defined in build
+  options.plugins.forEach(plugin => {
+    const pluginName = Array.isArray(plugin) ? plugin[0] : plugin;
+    let exists = false;
+
+    plugins.some((existingPlugin, idx) => {
+      const existingPluginName = Array.isArray(existingPlugin) ? existingPlugin[0] : existingPlugin;
+
+      // Overwrite if exists
+      if (pluginName == existingPluginName) {
+        plugins[idx] = plugin;
+        exists = true;
+      }
+
+      return exists;
+    });
+
+    if (!exists) plugins.push(plugin);
+  });
+
   // Add plugins based on version presets
   plugins = version.reduce(
     (plugins, preset) => {
@@ -214,25 +234,6 @@ function loadPluginsForType(type, options, version, compress) {
     plugins.push(...allPlugins[type].compress);
   }
 
-  // Add plugins defined in build
-  options.plugins.forEach(plugin => {
-    const pluginName = Array.isArray(plugin) ? plugin[0] : plugin;
-    let exists = false;
-
-    plugins.some((existingPlugin, idx) => {
-      const existingPluginName = Array.isArray(existingPlugin) ? existingPlugin[0] : existingPlugin;
-
-      // Overwrite if exists
-      if (pluginName == existingPluginName) {
-        plugins[idx] = plugin;
-        exists = true;
-      }
-
-      return exists;
-    });
-
-    if (!exists) plugins.push(plugin);
-  });
   options.plugins = plugins;
   // Store hash of plugin names
   options.fingerprint = md5(JSON.stringify(options));


### PR DESCRIPTION
When specifying optional postcss plugins, those are run after autoprefixer
and cssnano, which in som cases yields incorrect results.

Fixes https://github.com/popeindustries/buddy/issues/116